### PR TITLE
Bump node-gdal and allow null geoms

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,14 +24,12 @@ module.exports = function(infile, outfile, callback) {
   catch (err) { return callback(err); }
 
   inLayer.features.forEach(function(feature) {
-    var projected = feature.clone();
-    var geom;
-    try {
+    var projected = feature.clone(),
         geom = projected.getGeometry();
-    } catch (err) {
-      // for now, catch null geometries, add, and continue with next feature
+    
+    // Allow null geoms
+    if (!geom){
       outLayer.features.add(projected);
-      // skip to next feature
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wmshp",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/mapbox/node-wmshp",
   "dependencies": {
-    "gdal": "^0.4.1"
+    "gdal": "^0.4.2"
   },
   "devDependencies": {
     "jshint": "^2.6.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,17 +79,13 @@ test('Allow null geometry', function(assert) {
   wmshp(nullgeom, outfile, function(err){
     assert.ifError(err, 'no error');
     var ds = gdal.open(outfile);
-    //var expectedGeom = { type: 'Point', coordinates: [null, null] };
 
     ds.layers.forEach(function(layer) {
       assert.equal(layer.features.count(), 1, 'reprojected all features');
+      var feature = layer.features.get(0),
+          geojson = feature.getGeometry();
       
-      // Once node-gdal supports null geoms, check for null expected geom
-      
-      // var feature = layer.features.get(0),
-      //     geojson = JSON.parse(feature.getGeometry().toJSON());
-      
-      // assert.deepEqual(geojson, expectedGeom, 'checked feature has proper coordinates');
+      assert.deepEqual(geojson, null, 'checked feature has proper coordinates');
     });
     
     assert.end();


### PR DESCRIPTION
`null` now a valid geom value from node-gdal.

cc @rclark 
