### PR TITLE
Cropping is causing errors for all shapefiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,6 @@ var gdal = require('gdal');
 
 module.exports = function(infile, outfile, callback) {
   var sm = gdal.SpatialReference.fromEPSG(3857);
-  var world = gdal.Geometry.fromWKT(
-    'POLYGON((-180 -85.05133, 180 -85.05133, 180 85.05133, -180 85.05133, -180 -85.05133))',
-    gdal.SpatialReference.fromEPSG(4326)
-  );
   var inDs;
   var outDs;
 
@@ -41,7 +37,6 @@ module.exports = function(infile, outfile, callback) {
       return;
     }
 
-    geom = geom.intersection(world);
     geom.transformTo(sm);
     projected.setGeometry(geom);
     outLayer.features.add(projected);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var crypto = require('crypto');
 var wgs84 = path.join(__dirname, 'fixtures', 'wgs84', 'wgs84.shp');
 var nullgeom = path.join(__dirname, 'fixtures', 'nullgeom', 'null_geom.shp');
-var poles = path.join(__dirname, 'fixtures', 'poles', 'poles.shp');
+//var poles = path.join(__dirname, 'fixtures', 'poles', 'poles.shp');
 
 function truncate(num) {
   return Math.floor(num * Math.pow(10, 6)) / Math.pow(10, 6);
@@ -139,24 +139,24 @@ test('reproject from a folder', function(assert) {
   });
 });
 
-test('reproject features that go to 90/-90', function(assert) {
-  var outfolder = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
-  wmshp(poles, outfolder, function(err) {
-    assert.ifError(err, 'no error');
+// test('reproject features that go to 90/-90', function(assert) {
+//   var outfolder = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+//   wmshp(poles, outfolder, function(err) {
+//     assert.ifError(err, 'no error');
 
-    fs.readdir(outfolder, function(err, files) {
-      if (err) throw err;
+//     fs.readdir(outfolder, function(err, files) {
+//       if (err) throw err;
 
-      assert.equal(files.length, 4, 'gdal creates four files');
-      var extensions = files.map(function(filename) {
-        return path.extname(filename);
-      });
+//       assert.equal(files.length, 4, 'gdal creates four files');
+//       var extensions = files.map(function(filename) {
+//         return path.extname(filename);
+//       });
 
-      ['.dbf', '.prj', '.shp', '.shx'].forEach(function(extension) {
-        assert.ok(extensions.indexOf(extension) > -1, extension + ' file created');
-      });
+//       ['.dbf', '.prj', '.shp', '.shx'].forEach(function(extension) {
+//         assert.ok(extensions.indexOf(extension) > -1, extension + ' file created');
+//       });
 
-      assert.end();
-    });
-  });
-});
+//       assert.end();
+//     });
+//   });
+// });


### PR DESCRIPTION
Remove for now, until we can fine-tune cropping files with extents beyond/close to the dateline.

cc @rclark @BergWerkGIS 
