### PR TITLE
bump node-gdal, test on v4 v6 (remove v0.10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-- "0.10.35"
+  - "4"
+  - "6"
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0
+
+ - Upgraded to node-gdal@0.9.3
+ - Tests running on Node.js v4 & v6, no longer on v0.10.x
+
 ## 0.3.0
 
  - Upgraded to node-gdal@0.8.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wmshp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/mapbox/node-wmshp",
   "dependencies": {
-    "gdal": "~0.8.0"
+    "gdal": "~0.9.3"
   },
   "devDependencies": {
     "jshint": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wmshp",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -56,7 +56,7 @@ test('reprojects', function(assert) {
     if (i > 0) assert.fail('should have only one layer');
     i++;
 
-    assert.ok(!layer.srs.isSame(sm), 'reprojected');
+    assert.ok(layer.srs.isSame(sm), 'reprojected');
     assert.equal(layer.features.count(), 245, 'reprojected all features');
 
     var feature = layer.features.get(0);


### PR DESCRIPTION
- Updating to the new node-gdal release, which is a full minor to `0.9.3`. 
- Travis tests on node v4, v6, and remove v0.10.x

cc @springmeyer @who8mycakes @GretaCB 
